### PR TITLE
Install cron for the graphite cleanup crontab

### DIFF
--- a/cloudmon/ansible/project/roles/graphite/vars/Debian.yaml
+++ b/cloudmon/ansible/project/roles/graphite/vars/Debian.yaml
@@ -7,5 +7,7 @@ remove_packages: []
 
 packages:
   - netcat-openbsd
+  # ansible.builtin.cron needs the crontab binary.
+  - cron
 
 container_command: docker


### PR DESCRIPTION
Follow-up to #38.

Graphite provisioning got as far as `ok=12 changed=6` and then failed:

```
TASK [graphite : Run periodic cleanup]
Failed to find required executable "crontab" in paths: ...
```

The rewritten `vars/Debian.yaml` dropped `cron`, which `main` still lists. `graphite` is the only role using `ansible.builtin.cron` (the "Run periodic cleanup" task), and that module needs the `crontab` binary.

`apparmor-profiles` was dropped in the same rewrite, but it is never referenced by any task, so it stays out.